### PR TITLE
Correct Variable name while loading Estimated_HighLRMS bands

### DIFF
--- a/Fusion.m
+++ b/Fusion.m
@@ -112,10 +112,10 @@ Det = PanWV_db - I;
 
 %% Tiling the High resolution LRMS bands
 
-L = size(Patches_MS_U_1,2);
-N = size(Patches_MS_U_1,1);
+L = size(Decoded,2);
+N = size(Decoded,1);
 
-EHMS(:,:,1) = Tiling_av(Decoded(1:N,1:L), Patch_size, overlap, BlX, BlY, PadX, PadY, r, c);
+EHMS(:,:,1) = Tiling_av(Decoded(1:N,1:L/4), Patch_size, overlap, BlX, BlY, PadX, PadY, r, c);
 EHMS(:,:,2) = Tiling_av(Decoded(1:N,L+1:2*L), Patch_size, overlap, BlX, BlY, PadX, PadY, r, c);
 EHMS(:,:,3) = Tiling_av(Decoded(1:N,2*L+1:3*L), Patch_size, overlap, BlX, BlY, PadX, PadY, r, c);
 EHMS(:,:,4) = Tiling_av(Decoded(1:N,3*L+1:4*L), Patch_size, overlap, BlX, BlY, PadX, PadY, r, c);


### PR DESCRIPTION
Estimated_HighLRMS is saved with variable name Decoded, to retrieve it same variable name must be used.